### PR TITLE
Adapt to java8, remove the restriction of the projectId parameter, only need the built-in projectName and projectVersion, when the dtrack platform does not have this project, it will be created automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Configure your custom properties:
 dependencyTrack {
     host = 'your-dtrack-server-host'
     apiKey = 'your-dtrack-api-key'
-    projectId = 'your-dtrack-project-identifier'
+    projectName = 'your-project-name'   //optional
+    projectVersion = 'your-project-version'   //optional
 }
 tasks.named('dependencyTrack') {
     dependsOn cyclonedxBom
@@ -43,7 +44,8 @@ dependencyTrack {
     host = 'http://localhost:8081'
     realm = '/api/v1/bom'
     bomFile= file("${buildDir.path}/reports/bom.xml")
-    projectId = ''
+    projectName = ''
+    projectVersion = ''
     apiKey = ''
 }
 tasks.named('dependencyTrack') {

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ version version
 description = 'Gradle plugin to help publishing bom to Dependency-track'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
     withSourcesJar()
 }
 
@@ -36,8 +36,11 @@ gradlePlugin {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.mockito:mockito-core:3.12.4'
+    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'org.apache.httpcomponents:httpmime:4.5.13'
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.0
+version=1.0.0

--- a/src/main/java/com/trileuco/gradle/DTrackBody.java
+++ b/src/main/java/com/trileuco/gradle/DTrackBody.java
@@ -2,7 +2,7 @@ package com.trileuco.gradle;
 
 /**
  * Description:
- * Author: meijinye
+ * Author: killian
  * Date: 2023/7/8
  * Time: 22:27
  */

--- a/src/main/java/com/trileuco/gradle/DTrackBody.java
+++ b/src/main/java/com/trileuco/gradle/DTrackBody.java
@@ -1,0 +1,47 @@
+package com.trileuco.gradle;
+
+/**
+ * Description:
+ * Author: meijinye
+ * Date: 2023/7/8
+ * Time: 22:27
+ */
+public class DTrackBody {
+    private String projectId;
+    private String projectName;
+    private String projectVersion;
+    private boolean autoCreate;
+    private String bom;
+
+    public DTrackBody(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public DTrackBody(String projectName, String projectVersion, boolean autoCreate, String bom) {
+        this.projectName = projectName;
+        this.projectVersion = projectVersion;
+        this.autoCreate = autoCreate;
+        this.bom = bom;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public String getProjectVersion() {
+        return projectVersion;
+    }
+
+    public boolean isAutoCreate() {
+        return autoCreate;
+    }
+
+    public String getBom() {
+        return bom;
+    }
+
+}

--- a/src/main/java/com/trileuco/gradle/DeleteTask.java
+++ b/src/main/java/com/trileuco/gradle/DeleteTask.java
@@ -1,0 +1,25 @@
+package com.trileuco.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+
+public class DeleteTask extends DefaultTask {
+  private final DependencyTrackExtension extension;
+  public static final String TASK_NAME = "delete";
+
+  @Inject
+  public DeleteTask(DependencyTrackExtension extension) {
+    this.extension = extension;
+  }
+
+  @TaskAction
+  public void publish() {
+    extension.validate();
+    DependencyTrackClient client =
+        new DependencyTrackClient(
+            extension.getHost().get(), extension.getRealm().get(), extension.getApiKey().get());
+    client.delete(extension.getProjectName().get(), extension.getProjectVersion().get());
+  }
+}

--- a/src/main/java/com/trileuco/gradle/DependencyTrackExtension.java
+++ b/src/main/java/com/trileuco/gradle/DependencyTrackExtension.java
@@ -6,6 +6,8 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
+import javax.inject.Singleton;
+
 public class DependencyTrackExtension {
   public static final String DEPENDENCY_TRACK_EXTENSION_NAME = "dependencyTrack";
   public static final String DEPENDENCY_TRACK_TASK_NAME = "dependencyTrack";
@@ -13,6 +15,8 @@ public class DependencyTrackExtension {
   private final Property<String> host;
   private final Property<String> realm;
   private final Property<String> apiKey;
+  private final Property<String> projectName;
+  private final Property<String> projectVersion;
   private final Property<String> projectId;
   private final RegularFileProperty bomFile;
 
@@ -23,6 +27,8 @@ public class DependencyTrackExtension {
     this.realm = objects.property(String.class).convention("/api/v1/bom");
     this.bomFile =
         objects.fileProperty().fileValue(new File(project.getBuildDir(), "reports/bom.xml"));
+    this.projectName = objects.property(String.class).convention(project.getName());
+    this.projectVersion = objects.property(String.class).convention(project.getVersion().toString());
   }
 
   public void validate() {
@@ -33,10 +39,6 @@ public class DependencyTrackExtension {
     if (!apiKey.isPresent()) {
       throw new IllegalArgumentException(
           "'apiKey' is not set. Set the 'apiKey' to access the dependency-track server.");
-    }
-    if (!projectId.isPresent()) {
-      throw new IllegalArgumentException(
-          "'projectId' is not set. This is the uuid of the associated dependency-track project.");
     }
     if (bomFile.getAsFile().isPresent() && !bomFile.getAsFile().get().exists()) {
       throw new IllegalArgumentException(
@@ -58,6 +60,14 @@ public class DependencyTrackExtension {
 
   public Property<String> getProjectId() {
     return projectId;
+  }
+
+  public Property<String> getProjectName() {
+    return projectName;
+  }
+
+  public Property<String> getProjectVersion() {
+    return projectVersion;
   }
 
   public RegularFileProperty getBomFile() {

--- a/src/main/java/com/trileuco/gradle/DependencyTrackPlugin.java
+++ b/src/main/java/com/trileuco/gradle/DependencyTrackPlugin.java
@@ -7,9 +7,11 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskContainer;
 
 public class DependencyTrackPlugin implements Plugin<Project> {
   private static final Logger LOGGER = Logging.getLogger(DependencyTrackPlugin.class);
+  private static final String DEFAULT_GROUP = "dependency-track";
 
   @Override
   public void apply(Project project) {
@@ -20,10 +22,17 @@ public class DependencyTrackPlugin implements Plugin<Project> {
             .create(DEPENDENCY_TRACK_EXTENSION_NAME, DependencyTrackExtension.class);
 
     LOGGER.debug("Adding '{}' task to '{}'", DEPENDENCY_TRACK_TASK_NAME, project);
-    DependencyTrackTask dependencyTrack =
-        project.getTasks().create(DEPENDENCY_TRACK_TASK_NAME, DependencyTrackTask.class, extension);
-    dependencyTrack.setDescription(
-        "Publishes generated bom in " + project + " to Dependency-Track server.");
-    dependencyTrack.setGroup("Reporting");
+    TaskContainer projectTasks = project.getTasks();
+
+    UploadTask uploadTask =
+            projectTasks.create(UploadTask.TASK_NAME, UploadTask.class, extension);
+    uploadTask.setGroup(DEFAULT_GROUP);
+    uploadTask.setDescription("Upload bom to Dependency-Track server.");
+
+    DeleteTask deleteTask =
+            projectTasks.create(DeleteTask.TASK_NAME, DeleteTask.class, extension);
+    deleteTask.setGroup(DEFAULT_GROUP);
+    deleteTask.setDescription("Delete project from Dependency-Track server.");
+
   }
 }

--- a/src/main/java/com/trileuco/gradle/UploadTask.java
+++ b/src/main/java/com/trileuco/gradle/UploadTask.java
@@ -1,23 +1,28 @@
 package com.trileuco.gradle;
 
-import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
-public class DependencyTrackTask extends DefaultTask {
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class UploadTask extends DefaultTask {
   private final DependencyTrackExtension extension;
+  public static final String TASK_NAME = "upload";
 
   @Inject
-  public DependencyTrackTask(DependencyTrackExtension extension) {
+  public UploadTask(DependencyTrackExtension extension) {
     this.extension = extension;
   }
 
   @TaskAction
   public void publish() {
-    extension.validate();
     DependencyTrackClient client =
         new DependencyTrackClient(
             extension.getHost().get(), extension.getRealm().get(), extension.getApiKey().get());
-    client.publish(extension.getProjectId().get(), extension.getBomFile().get().getAsFile());
+    client.publish(extension.getProjectName().get(),
+            extension.getProjectVersion().get(),
+            extension.getBomFile().get().getAsFile());
   }
 }

--- a/src/test/java/ActionTest.java
+++ b/src/test/java/ActionTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Description:
- * Author: meijinye
+ * Author: killian
  * Date: 2023/7/9
  * Time: 12:15
  */

--- a/src/test/java/ActionTest.java
+++ b/src/test/java/ActionTest.java
@@ -1,0 +1,36 @@
+import com.trileuco.gradle.DependencyTrackExtension;
+import com.trileuco.gradle.UploadTask;
+import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Description:
+ * Author: meijinye
+ * Date: 2023/7/9
+ * Time: 12:15
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ActionTest {
+    @Mock
+    private UploadTask uploadTask;
+    @Mock
+    private Project project;
+    @Mock
+    private ObjectFactory objectFactory;
+    @Mock
+    private DependencyTrackExtension dependencyTrackExtension;
+
+    @Test
+    public void upload() {
+//        uploadTask.publish();
+    }
+}


### PR DESCRIPTION
Adapt to java8, remove the restriction of the projectId parameter, only need the built-in projectName and projectVersion, when the dtrack platform does not have this project, it will be created automatically